### PR TITLE
fix: better diagnosed gRPC status code in monitor middleware

### DIFF
--- a/middleware/interceptors/server/monitor.go
+++ b/middleware/interceptors/server/monitor.go
@@ -45,6 +45,9 @@ func MonitorGRPCInterceptor(deps gRPCMetricInterceptorsDeps) grpc.UnaryServerInt
 }
 
 func gRPCCodeTagValue(err error) string {
-	s, _ := status.FromError(err)
+	s, ok := status.FromError(err)
+	if !ok {
+		s = status.FromContextError(err)
+	}
 	return strconv.Itoa(int(s.Code()))
 }


### PR DESCRIPTION
This change aligns status code retrieval from error with what the gRPC server logic does:
1. status.FromError
2. status.FromContextError

https://github.com/grpc/grpc-go/blob/master/server.go#L1369-L1377