### PR TITLE
Add support for gRPC stream server interceptors

### DIFF
--- a/providers/groups/alias.go
+++ b/providers/groups/alias.go
@@ -34,6 +34,9 @@ const (
 	// UnaryServerInterceptors - GRPC Unary Server Interceptors group. Register different gRPC server interceptors
 	UnaryServerInterceptors = partial.FxGroupUnaryServerInterceptors
 
+	// StreamServerInterceptors - GRPC Stream Server Interceptors group. Register different gRPC server interceptors
+	StreamServerInterceptors = partial.FxGroupStreamServerInterceptors
+
 	// InternalHTTPHandlers - Internal Http Handlers group. Mortar comes with several internal handlers, you can add yours.
 	InternalHTTPHandlers = partial.FxGroupInternalHTTPHandlers
 


### PR DESCRIPTION
## Description
This PR adds support for **gRPC stream server interceptors**, extending the current interceptor configuration which was previously limited to unary server interceptors only.

## Motivation
Many gRPC use cases require stream-level interception (e.g., logging, authentication, tracing). This addition provides greater flexibility with tools such as [Zitadel](https://zitadel.com) which require both unary and stream server interception.

## Details
A new group (streamServerInterceptors) was added to the HTTPServerBuilder's deps, that allows providing stream server interceptors like this:

```go
fx.Provide(fx.Annotated{
    Group: groups.StreamServerInterceptors,
    Target: func(mw *Middleware) grpc.StreamServerInterceptor {
        return mw.Stream()
    },
})
```


Let me know if any adjustments are needed or if you'd like the change split into smaller commits. Thanks for reviewing!